### PR TITLE
updated to CA_BUNDLE retrieval universal command

### DIFF
--- a/deployment/webhook-patch-ca-bundle.sh
+++ b/deployment/webhook-patch-ca-bundle.sh
@@ -6,7 +6,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export CA_BUNDLE=$(kubectl config view --raw -o json | jq -r '.clusters[0].cluster."certificate-authority-data"' | tr -d '"')
+
+export CA_BUNDLE=$(kubectl config view --raw --flatten -o json | jq -r '.clusters[] | select(.name == "'$(kubectl config current-context)'") | .cluster."certificate-authority-data"')
 
 if command -v envsubst >/dev/null 2>&1; then
     envsubst


### PR DESCRIPTION
The command you use to retrieve the CA_BUNDLE assumes the config is in the first configuration entry.  The new command should work in all places including EKS.
