### PR TITLE
Fix Service Name in ValidatingWebhookConfiguration

### DIFF
--- a/deployment/validatingwebhook.yaml
+++ b/deployment/validatingwebhook.yaml
@@ -8,7 +8,7 @@ webhooks:
   - name: required-labels.banzaicloud.com
     clientConfig:
       service:
-        name: admission-webhook-example-webhook-svc
+        name: admission-webhook-example-svc
         namespace: default
         path: "/validate"
       caBundle: ${CA_BUNDLE}


### PR DESCRIPTION
Bring parity in the names of the actual _service_ deployed (*admission-webhook-example-svc*) and the service referenced in ValidatingWebhookConfiguration's ClientConfig (*admission-webhook-example-webhook-svc*). This results in the deployment object being created (it should not be according to the Validating Webhook) as the service referenced doesn't exist.