### PR TITLE
Rename clientConfig.service.name to suitable name

### DIFF
--- a/deployment/validatingwebhook.yaml
+++ b/deployment/validatingwebhook.yaml
@@ -8,7 +8,7 @@ webhooks:
   - name: required-labels.banzaicloud.com
     clientConfig:
       service:
-        name: admission-webhook-example-webhook-svc
+        name: admission-webhook-example-svc
         namespace: default
         path: "/validate"
       caBundle: ${CA_BUNDLE}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | clientConfig.service.name  spelling mistakes
| License         | Apache 2.0


### What's in this PR?
Rename clientConfig.service.name to suitable name in deployment/validatingwebhook.yaml.

### Why?
```bash
# kubectl get svc 
NAME                            TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
admission-webhook-example-svc   ClusterIP   192.168.0.226   <none>        443/TCP   33m
```
The clientConfig.service.name is different from k8s service name, So kube-apiserver can't connect to webhook server successfully.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
